### PR TITLE
Change recv and get to return hashes.

### DIFF
--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -20,11 +20,11 @@ $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 $mq->consume(1, 'new-orders');
 
 my $msg = $mq->recv;
-cmp_ok($msg, 'eq', 'hello!', 'recv got the message');
+cmp_ok($msg->{body}, 'eq', 'hello!', 'recv got the message');
 
 $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 
 my $msg2 = $mq->get(1, 'new-orders', {});
-cmp_ok($msg2, 'eq', 'hello!', 'get got the message');
+cmp_ok($msg2->{body}, 'eq', 'hello!', 'get got the message');
 
 done_testing;

--- a/t/wildcard.t
+++ b/t/wildcard.t
@@ -23,25 +23,25 @@ $mq->queue_bind(1, 'bar4', 'foo', 'foo.#');
 
 $mq->publish(1, 'foo.bar', 'hello!', { exchange => 'foo' });
 my $msg = $mq->get(1, 'bar1', {});
-cmp_ok($msg, 'eq', 'hello!', 'get got the message (foo.bar)');
+cmp_ok($msg->{body}, 'eq', 'hello!', 'get got the message (foo.bar)');
 
 my $msg2 = $mq->get(1, 'bar4', {});
-cmp_ok($msg2, 'eq', 'hello!', 'get got the message in the wildcard queue (foo.bar)');
+cmp_ok($msg2->{body}, 'eq', 'hello!', 'get got the message in the wildcard queue (foo.bar)');
 
 $mq->publish(1, 'foo.ass.zot', 'hello!', { exchange => 'foo' });
 my $msg3 = $mq->get(1, 'bar2', {});
-cmp_ok($msg3, 'eq', 'hello!', 'get got foo.*.zot message (foo.ass.zot)');
+cmp_ok($msg3->{body}, 'eq', 'hello!', 'get got foo.*.zot message (foo.ass.zot)');
 my $msg4 = $mq->get(1, 'bar3', {});
-cmp_ok($msg4, 'eq', 'hello!', 'get got foo.#.zot message (foo.ass.zot)');
+cmp_ok($msg4->{body}, 'eq', 'hello!', 'get got foo.#.zot message (foo.ass.zot)');
 
 $mq->publish(1, 'foo.ass.hat.zot', 'hello!', { exchange => 'foo' });
 my $msg5 = $mq->get(1, 'bar4', {});
-cmp_ok($msg5, 'eq', 'hello!', 'get got foo.# message (foo.ass.hat.zot)');
+cmp_ok($msg5->{body}, 'eq', 'hello!', 'get got foo.# message (foo.ass.hat.zot)');
 
 my $msg6 = $mq->get(1, 'bar3', {});
-cmp_ok($msg6, 'eq', 'hello!', 'get got foo.#.zot message (foo.ass.hat.zot)');
+cmp_ok($msg6->{body}, 'eq', 'hello!', 'get got foo.#.zot message (foo.ass.hat.zot)');
 
 my $msg7 = $mq->get(1, 'bar2', {});
-ok(!defined($msg7), 'get did not get foo.*.zot message (foo.ass.hat.zot)');
+ok(!defined($msg7->{body}), 'get did not get foo.*.zot message (foo.ass.hat.zot)');
 
 done_testing;


### PR DESCRIPTION
Rather than just return the body of the queued message, return all the
metainformation that Net::RabbitMQ would have returned.  I made a
minimial effort to keep delivery_tags unique, but not by channel,
they're just a global counter.

routing_key, exchange and $props are passed unchanged.

redelivered, message_count, and consumer_tag I've left with default
values, mostly because I'm not sure what they should return.
