### PR TITLE
Make message props default to an empty hash

### DIFF
--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -497,7 +497,7 @@ sub _publish {
                 body         => $body,
                 routing_key  => $routing_key,
                 exchange     => $exchange,
-                props        => $props,
+                props        => $props || {},
             };
             push(@{ $self->_get_queue($binds->{$pattern}) }, $message);
         }


### PR DESCRIPTION
This is how Net::AMQP::RabbitMQ works.
