### PR TITLE
Don't wipe out pending messages when queue_declare is called

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Test-Net-RabbitMQ
 {{$NEXT}}
 
 0.10 Oct 11 2014
+    * Message properties now default to an empty hash if none are
+      specified. This matches the behavior of Net::AMQP::RabbitMQ. (Dave
+      Rolsky)
 
 0.09 Jun 30 2012
     * Add tx_select, tx_commit, and tx_rollback support. (bluefeet)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Test-Net-RabbitMQ
 
 {{$NEXT}}
+    * Calling queue_declare would wipe out the contents of the queue if it
+      already existed. (Dave Rolsky)
 
 0.10 Oct 11 2014
     * Message properties now default to an empty hash if none are

--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -428,7 +428,7 @@ sub queue_declare {
 
     die "Unknown channel: $channel" unless $self->_channel_exists($channel);
 
-    $self->_set_queue($queue, []);
+    $self->_set_queue($queue, []) unless $self->_queue_exists($queue);
 }
 
 =method queue_unbind($channel, $queue, $exchange, $routing_key)

--- a/t/queue.t
+++ b/t/queue.t
@@ -1,0 +1,27 @@
+use Test::More;
+use Test::Exception;
+
+use Test::Net::RabbitMQ;
+
+my $mq = Test::Net::RabbitMQ->new;
+isa_ok($mq, 'Test::Net::RabbitMQ', 'instantiated');
+
+$mq->connect;
+
+$mq->channel_open(1);
+
+$mq->exchange_declare(1, 'ex');
+$mq->queue_declare(1, 'bind-twice');
+$mq->queue_bind(1, 'bind-twice', 'ex', 'key');
+$mq->publish(
+    1, 'key', 'message body',
+    { exchange     => 'ex' },
+    { content_type => 'text/plain' }
+);
+$mq->queue_declare(1, 'bind-twice');
+
+my $msg = $mq->get(1, 'bind-twice');
+ok($msg, 'got message after calling queue_declare');
+is($msg->{body}, 'message body', 'message body contains expected content');
+
+done_testing;


### PR DESCRIPTION
This isn't how RabbitMQ itself works, and it definitely breaks some pretty normal test cases.

I also added in Changes that were missing for the previous (0.10) release.
