### PR TITLE
Add redelivered to message hashref returned by recv()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Test-Net-RabbitMQ
 
 {{$NEXT}}
+    * Added the redelivered key to messages returned by recv(). This matches a
+      change in Net::AMQP::RabbitMQ 0.007002. (Dave Rolsky)
+
     * Calling queue_declare would wipe out the contents of the queue if it
       already existed. (Dave Rolsky)
 

--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -517,6 +517,7 @@ information:
        routing_key => 'nr_test_q',        # route the message took
        exchange => 'nr_test_x',           # exchange used
        delivery_tag => 1,                 # (inc'd every recv or get)
+       redelivered => $boolean            # if message is redelivered
        consumer_tag => '',                # Always blank currently
        props => $props,                   # hashref sent in
      }
@@ -537,6 +538,7 @@ sub recv {
 
     $message->{delivery_tag} = $self->_inc_delivery_tag;
     $message->{consumer_tag} = '';
+    $message->{redelivered}  = 0;
 
     return $message;
 }

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -21,6 +21,7 @@ $mq->consume(1, 'new-orders');
 
 my $msg = $mq->recv;
 cmp_ok($msg->{body}, 'eq', 'hello!', 'recv got the message');
+ok(exists $msg->{redelivered}, 'msg has redelivered key');
 
 $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 


### PR DESCRIPTION
There is a corresponding PR for Net::AMQP::RabbitMQ, so I optimistically stated that this will be in the 0.007002 release of said module.

The PR is at https://github.com/markwellis/net-amqp-rabbitmq/pull/28. It probably doesn't make sense to release this module until that one is released with the same change.
