### PR TITLE
Sync up with latest Net::AMQP::RabbitMQ changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Test-Net-RabbitMQ
 
 {{$NEXT}}
+    * Added the redelivered key to messages returned by recv(). This matches a
+      change in Net::AMQP::RabbitMQ 0.007002. (Dave Rolsky)
+
     * Calling queue_declare would wipe out the contents of the queue if it
       already existed. (Dave Rolsky)
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@ Revision history for Test-Net-RabbitMQ
       methods. These aren't very smart and will not throw errors when the real
       RabbitMQ would, but the methods at least exist and delete any existing
       mock queue or exchange. (Dave Rolsky)
+    * Implement "passive => 1" option for queue_declare, primarily to make it
+      possible to get a queue's message count. (Dave Rolsky)
 
     * Calling queue_declare would wipe out the contents of the queue if it
       already existed. (Dave Rolsky)

--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Test-Net-RabbitMQ
 {{$NEXT}}
     * Added the redelivered key to messages returned by recv(). This matches a
       change in Net::AMQP::RabbitMQ 0.007002. (Dave Rolsky)
+    * The consume() method now returns a consumer tag, either the one you pass
+      or an auto-generated tag. (Dave Rolsky)
+    * Implemented a cancel() method. (Dave Rolsky)
 
     * Calling queue_declare would wipe out the contents of the queue if it
       already existed. (Dave Rolsky)

--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ Revision history for Test-Net-RabbitMQ
     * The consume() method now returns a consumer tag, either the one you pass
       or an auto-generated tag. (Dave Rolsky)
     * Implemented a cancel() method. (Dave Rolsky)
+    * Partially implemented exchange_delete() and queue_delete()
+      methods. These aren't very smart and will not throw errors when the real
+      RabbitMQ would, but the methods at least exist and delete any existing
+      mock queue or exchange. (Dave Rolsky)
 
     * Calling queue_declare would wipe out the contents of the queue if it
       already existed. (Dave Rolsky)

--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -517,6 +517,7 @@ information:
        routing_key => 'nr_test_q',        # route the message took
        exchange => 'nr_test_x',           # exchange used
        delivery_tag => 1,                 # (inc'd every recv or get)
+       redelivered => $boolean            # if message is redelivered
        consumer_tag => '',                # Always blank currently
        props => $props,                   # hashref sent in
      }
@@ -537,6 +538,7 @@ sub recv {
 
     $message->{delivery_tag} = $self->_inc_delivery_tag;
     $message->{consumer_tag} = '';
+    $message->{redelivered}  = 0;
 
     return $message;
 }

--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -300,6 +300,22 @@ sub exchange_declare {
     $self->_set_exchange($exchange, 1);
 }
 
+=method exchange_delete($channel, $exchange, $options)
+
+Deletes an exchange of the specified name.
+
+=cut
+
+sub exchange_delete {
+    my ($self, $channel, $exchange, $options) = @_;
+
+    die "Not connected" unless $self->connected;
+
+    die "Unknown channel" unless $self->_channel_exists($channel);
+
+    $self->_remove_exchange($exchange);
+}
+
 =method tx_select($channel)
 
 Begins a transaction on the specified channel.  From this point forward all
@@ -459,6 +475,22 @@ sub queue_declare {
     die "Unknown channel: $channel" unless $self->_channel_exists($channel);
 
     $self->_set_queue($queue, []) unless $self->_queue_exists($queue);
+}
+
+=method queue_delete($channel, $queue, $options)
+
+Deletes a queue of the specified name.
+
+=cut
+
+sub queue_delete {
+    my ($self, $channel, $queue, $options) = @_;
+
+    die "Not connected" unless $self->connected;
+
+    die "Unknown channel" unless $self->_channel_exists($channel);
+
+    $self->_remove_queue($queue);
 }
 
 =method queue_unbind($channel, $queue, $exchange, $routing_key)

--- a/lib/Test/Net/RabbitMQ.pm
+++ b/lib/Test/Net/RabbitMQ.pm
@@ -494,6 +494,10 @@ sub publish {
     my $self = shift;
     my $channel = shift;
 
+    die "Not connected" unless $self->connected;
+
+    die "Unknown channel: $channel" unless $self->_channel_exists($channel);
+
     my $messages = $self->_tx_messages->{ $channel };
     if ($messages) {
         push @$messages, [ @_ ];
@@ -505,10 +509,6 @@ sub publish {
 
 sub _publish {
     my ($self, $channel, $routing_key, $body, $options, $props) = @_;
-
-    die "Not connected" unless $self->connected;
-
-    die "Unknown channel: $channel" unless $self->_channel_exists($channel);
 
     my $exchange = $options->{exchange};
     unless($exchange) {

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -17,15 +17,29 @@ $mq->queue_bind(1, 'new-orders', 'order', 'order.new');
 
 $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 
-$mq->consume(1, 'new-orders');
+my $ctag = $mq->consume(1, 'new-orders');
+like($ctag, qr/^[\w-]+$/, 'got a sane consumer tag back from consume');
 
 my $msg = $mq->recv;
 cmp_ok($msg->{body}, 'eq', 'hello!', 'recv got the message');
 ok(exists $msg->{redelivered}, 'msg has redelivered key');
 
+ok($mq->cancel(1, $ctag), 'cancel');
+ok(!$mq->cancel(1, $ctag), 'cancel returns false without a matching consume');
+
+dies_ok { $mq->cancel } 'must provide a channel to cancel';
+dies_ok { $mq->cancel(1) } 'must provide a consumer tag to cancel';
+dies_ok { $mq->cancel(1, undef) } 'must provide a non-undef consumer tag to cancel';
+
 $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 
 my $msg2 = $mq->get(1, 'new-orders', {});
 cmp_ok($msg2->{body}, 'eq', 'hello!', 'get got the message');
+
+$mq->disconnect;
+
+for my $meth (qw( publish consume recv cancel ) ) {
+    dies_ok { $mq->$meth } "cannot call $meth if not connected";
+}
 
 done_testing;

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -21,6 +21,7 @@ $mq->consume(1, 'new-orders');
 
 my $msg = $mq->recv;
 cmp_ok($msg->{body}, 'eq', 'hello!', 'recv got the message');
+ok(exists $msg->{redelivered}, 'msg has redelivered key');
 
 $mq->publish(1, 'order.new', 'hello!', { exchange => 'order' });
 

--- a/t/queue.t
+++ b/t/queue.t
@@ -24,4 +24,7 @@ my $msg = $mq->get(1, 'bind-twice');
 ok($msg, 'got message after calling queue_declare');
 is($msg->{body}, 'message body', 'message body contains expected content');
 
+lives_ok { $mq->queue_delete(1, 'bind-twice') } 'queue_delete';
+lives_ok { $mq->exchange_delete(1, 'bind-twice') } 'ex';
+
 done_testing;


### PR DESCRIPTION
- Make messages returned by `recv()` include a redelivered flag.
- Make `consume()` return a consumer tag.
- Implemented `cancel()`.
